### PR TITLE
Fixed problems caused by usage of db context by multiple threads

### DIFF
--- a/UhlnocsServer/Database/Repository.cs
+++ b/UhlnocsServer/Database/Repository.cs
@@ -2,47 +2,50 @@
 {
     public class Repository<T> : IRepository<T> where T : class
     {
-        private ApplicationDatabaseContext AppDbContext;
-
-        public Repository(ApplicationDatabaseContext appDbContext)
+        public Repository()
         {
-            AppDbContext = appDbContext;
+
         }
 
         public async Task Create(T entity)
         {
-            var dbSet = AppDbContext.Set<T>();
+            ApplicationDatabaseContext appDbContext = new();
+            var dbSet = appDbContext.Set<T>();
             dbSet.Add(entity);
-            await AppDbContext.SaveChangesAsync();
+            await appDbContext.SaveChangesAsync();
         }
 
         public IQueryable<T> Get()
         {
-            var dbSet = AppDbContext.Set<T>();
+            ApplicationDatabaseContext appDbContext = new();
+            var dbSet = appDbContext.Set<T>();
             return dbSet.AsQueryable();
         }
 
         public async Task<T?> GetById(string id)
         {
-            var dbSet = AppDbContext.Set<T>();
+            ApplicationDatabaseContext appDbContext = new();
+            var dbSet = appDbContext.Set<T>();
             return await dbSet.FindAsync(id);
         }
 
         public async Task Update(T entity)
         {
-            var dbSet = AppDbContext.Set<T>();
+            ApplicationDatabaseContext appDbContext = new();
+            var dbSet = appDbContext.Set<T>();
             dbSet.Update(entity);
-            await AppDbContext.SaveChangesAsync();
+            await appDbContext.SaveChangesAsync();
         }
 
         public async Task Delete(string id)
         {
+            ApplicationDatabaseContext appDbContext = new();
             var entity = await GetById(id);
             if (entity != null)
             {
-                var dbSet = AppDbContext.Set<T>();
+                var dbSet = appDbContext.Set<T>();
                 dbSet.Remove(entity);
-                await AppDbContext.SaveChangesAsync();
+                await appDbContext.SaveChangesAsync();
             }
         }
     }

--- a/UhlnocsServer/Program.cs
+++ b/UhlnocsServer/Program.cs
@@ -15,8 +15,6 @@ namespace UhlnocsServer
 
             builder.Services.AddGrpc();
 
-            builder.Services.AddTransient<ApplicationDatabaseContext>();
-
             builder.Services.AddSingleton<UserService>();
             builder.Services.AddSingleton<ModelService>();
             builder.Services.AddSingleton<CalculationService>();


### PR DESCRIPTION
This is necessary because of
https://learn.microsoft.com/en-us/ef/core/dbcontext-configuration/#avoiding-dbcontext-threading-issues